### PR TITLE
Corrige caminho dos arquivos de teste

### DIFF
--- a/test/RodoviaServiceTest.cs
+++ b/test/RodoviaServiceTest.cs
@@ -9,26 +9,32 @@ namespace test.RodoviaServiceTests
     {
         private readonly RodoviaService rodoviaService;
         private readonly Mock<IRodoviaRepositorio> mockRodoviaRepositorio;
-        private readonly string caminhoDoArquivo;
+        private string caminhoDoArquivo;
+        private readonly string caminhoTests = Path.Join("..", "..", "..", "..", "test");
+
+
         public RodoviaServiceTest()
         {
-            caminhoDoArquivo = "..\\..\\..\\..\\test\\Stub\\planilhaExemplo.csv";
+            caminhoDoArquivo = Path.Join(caminhoTests, "Stub", "planilhaExemplo.csv");
             mockRodoviaRepositorio = new();
             rodoviaService = new RodoviaService(mockRodoviaRepositorio.Object);
         }
+
         [Fact]
         public void CadastrarRodoviaViaPlanilha_QuandoPlanilhaForPassadaENaoTiverDado_NaoDevePassarPeloRepositorio()
         {
             Assert.Throws<ArgumentNullException>(() => rodoviaService.CadastrarRodoviaViaPlanilha(null));
         }
+
         [Fact]
         public void CadastrarRodoviaViaPlanilha_QuandoForChamado_DeveChamarORepositorio()
-        {;
+        {
             var memoryStream = new MemoryStream(File.ReadAllBytes(caminhoDoArquivo));
 
             rodoviaService.CadastrarRodoviaViaPlanilha(memoryStream);
             mockRodoviaRepositorio.Verify(mock => mock.CadastrarRodovia(It.IsAny<RodoviaDTO>()), Times.Exactly(3));
         }
+
         [Fact]
         public void CadastrarRodoviaViaPlanilha_QuandForChamado_DeveCadastrarRodovias()
         {
@@ -41,14 +47,13 @@ namespace test.RodoviaServiceTests
         [Fact]
         public void SuperaTamanhoMaximo_QuandoPlanilhaComTamanhoMaiorQueOMaximoForPassada_DeveRetornarTrue()
         {
-            string caminhoArquivo = "..\\..\\..\\..\\test\\Stub\\planilha_tamanho_max.csv";
-
-        MemoryStream memoryStream = new MemoryStream(File.ReadAllBytes(caminhoArquivo));
+            caminhoDoArquivo = Path.Join(caminhoTests, "Stub", "planilha_tamanho_max.csv");
+            
+            MemoryStream memoryStream = new MemoryStream(File.ReadAllBytes(caminhoDoArquivo));
 
             bool resultado = rodoviaService.SuperaTamanhoMaximo(memoryStream);
 
             Assert.True(resultado);
         }
     }
-
 }

--- a/test/SinistroServiceTest.cs
+++ b/test/SinistroServiceTest.cs
@@ -1,12 +1,8 @@
 using Moq;
 using service;
-using repositorio;
 using service.Interfaces;
 using repositorio.Interfaces;
 using dominio;
-
-using System.IO;
-
 
 namespace test.SinistroServiceTests
 {
@@ -14,18 +10,22 @@ namespace test.SinistroServiceTests
     {
         private readonly SinistroService sinistroService;
         private readonly Mock<ISinistroRepositorio> mockSinistroRepositorio;
-        private readonly string caminhoDoArquivo;
+        private string caminhoDoArquivo;
+        private readonly string caminhoTests = Path.Join("..", "..", "..", "..", "test");
+
         public SinistroServiceTest()
         {
-            caminhoDoArquivo = "..\\..\\..\\..\\test\\Stub\\ExemploSin.csv";
+            caminhoDoArquivo = Path.Join(caminhoTests, "Stub", "ExemploSin.csv");
             mockSinistroRepositorio = new();
             sinistroService = new SinistroService(mockSinistroRepositorio.Object);
         }
+
         [Fact]
         public void CadastrarSinistroViaPlanilha_QuandoPlanilhaForPassadaENaoTiverDado_NaoDevePassarPeloRepositorio()
         {
             Assert.Throws<ArgumentNullException>(() => sinistroService.CadastrarSinistroViaPlanilha(null));
         }
+
         [Fact]
         public void CadastrarSinistroViaPlanilha_QuandoForChamado_DeveChamarORepositorio()
         {
@@ -34,6 +34,7 @@ namespace test.SinistroServiceTests
             sinistroService.CadastrarSinistroViaPlanilha(memoryStream);
             mockSinistroRepositorio.Verify(mock => mock.CadastrarSinistro(It.IsAny<Sinistro>()), Times.Exactly(3));
         }
+
         [Fact]
         public void CadastrarSinistroViaPlanilha_QuandForChamado_DeveCadastrarSinistros()
         {
@@ -49,9 +50,9 @@ namespace test.SinistroServiceTests
             Mock<ISinistroRepositorio> mockSinistroRepositorio = new();
             ISinistroService sinistroService = new SinistroService(mockSinistroRepositorio.Object);
 
-            string caminhoArquivo = "..\\..\\..\\..\\test\\Stub\\planilhaExemploSinistro.csv";
+            caminhoDoArquivo = Path.Join(caminhoTests, "Stub", "planilhaExemploSinistro.csv");
 
-            MemoryStream memoryStream = new MemoryStream(File.ReadAllBytes(caminhoArquivo));
+            MemoryStream memoryStream = new MemoryStream(File.ReadAllBytes(caminhoDoArquivo));
 
             bool resultado = sinistroService.SuperaTamanhoMaximo(memoryStream);
 


### PR DESCRIPTION
Os testes estavam quebrando em ambiente Linux por causa do separador `\`. Agora os testes usam o método `.Join()` que funciona em múltiplos SOs.